### PR TITLE
LCH-6136: Updated acquia-php-sdk-2 version constraint.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-json": "*",
         "acquia/contenthub-console-helpers": "main-dev",
-        "typhonius/acquia-php-sdk-v2": "<=2.0.15"
+        "typhonius/acquia-php-sdk-v2": "<=2.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "ext-json": "*",
         "acquia/contenthub-console-helpers": "main-dev",
-        "typhonius/acquia-php-sdk-v2": "<=2.2.0"
+        "typhonius/acquia-php-sdk-v2": ">=2.0.15"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Fixtures/ace_environment_response.php
+++ b/tests/Fixtures/ace_environment_response.php
@@ -29,6 +29,7 @@ return [
       ],
     'region' => 'us-east-1',
     'balancer' => 'balancers',
+    'platform' => 'platform',
     'status' => 'normal',
     'type' => 'drupal',
     'size' => NULL,


### PR DESCRIPTION
$platform property was introduced in EnvironmentResponse.php class: https://github.com/typhonius/acquia-php-sdk-v2/commit/49fceb757daac188a3d808ccdd06b08f5ffc6824
In 2.0.16 release of typhonius/acquia-php-sdk-v2